### PR TITLE
add macro button code value

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -75,7 +75,7 @@ dpi_5_color = {mouse.raw_dpi_colors[12:15]}
 ; These parameters are setting certain mouse buttons
 ; Possible values: left, right, middle, back, forward,
 ; scroll_up, scroll_down, double_click, triple_click,
-; dpi_loop, dpi_up, dpi_down, disable_button, switch_effect, change_mode
+; dpi_loop, dpi_up, dpi_down, disable_button, switch_effect, macro, change_mode
 ; You can also bin key combinations, for example:
 ; ctrl_b
 ; ctrl_shift_b

--- a/default_settings.ini
+++ b/default_settings.ini
@@ -38,7 +38,7 @@ dpi_5_color = [255, 255, 0]
 ; These parameters are setting certain mouse buttons
 ; Possible values: left, right, middle, back, forward,
 ; scroll_up, scroll_down, double_click, triple_click,
-; dpi_loop, dpi_up, dpi_down, disable_button, switch_effect, change_mode
+; dpi_loop, dpi_up, dpi_down, disable_button, switch_effect, macro, change_mode
 ; You can also bin key combinations, for example:
 ; ctrl_b
 ; ctrl_shift_b
@@ -172,7 +172,7 @@ dpi_5_color = [255, 255, 0]
 ; These parameters are setting certain mouse buttons
 ; Possible values: left, right, middle, back, forward,
 ; scroll_up, scroll_down, double_click, triple_click,
-; dpi_loop, dpi_up, dpi_down, disable_button, switch_effect, change_mode
+; dpi_loop, dpi_up, dpi_down, disable_button, switch_effect, macro, change_mode
 ; You can also bin key combinations, for example:
 ; ctrl_b
 ; ctrl_shift_b

--- a/values.py
+++ b/values.py
@@ -56,6 +56,7 @@ buttons_codes = {
     'disable_lighting': [0x50, 0x02, 0, 0],
     'change_mode': [0x50, 0x06, 0, 0],
     'switch_effect': [0x50, 0x07, 0, 0],
+    'macro': [112, 1, 1, 1],
     **key_combinations_codes
 }
 


### PR DESCRIPTION
If the official software on Windows was previously used to set one of the M601-RGB's buttons to a custom macro, python would throw an unhanded value error. I have merely added that value (112, 1, 1, 1) as a new "macro" button code value. This doesn't allow us to edit or restore a working macro, but it will allow us to get beyond the error and use the script to change the button's code value to another option.